### PR TITLE
enable building on macos with homebrew

### DIFF
--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -1,6 +1,29 @@
 cmake_minimum_required(VERSION 3.12...3.18)
 project(eigen_cg)
 
+# Set USE_HOMEBREW to ON or OFF based on the environment variable
+if(DEFINED ENV{USE_HOMEBREW})
+    if("$ENV{USE_HOMEBREW}" STREQUAL "ON")
+        set(USE_HOMEBREW ON)
+    else()
+        set(USE_HOMEBREW OFF)
+    endif()
+else()
+    set(USE_HOMEBREW OFF)
+endif()
+
+if(USE_HOMEBREW)
+    # Set HOMEBREW_OMP_PATH based on the environment variable or a default value
+    if(DEFINED ENV{HOMEBREW_OMP_PATH})
+        set(HOMEBREW_OMP_PATH "$ENV{HOMEBREW_OMP_PATH}")
+    else()
+        set(HOMEBREW_OMP_PATH "/opt/homebrew/opt/libomp")
+    endif()
+
+    # Append HOMEBREW_OMP_PATH to CMAKE_PREFIX_PATH
+    list(APPEND CMAKE_PREFIX_PATH ${HOMEBREW_OMP_PATH})
+endif()
+
 find_package(pybind11)
 pybind11_add_module(eigen_cg src/CGsolver/eigen_cg.cpp)
 
@@ -10,7 +33,7 @@ link_directories(${EIGEN3_INCLUDE_DIRS})
 
 target_link_libraries(${PROJECT_NAME}
    PUBLIC Eigen3::Eigen
-   )
+)
 
 find_package(OpenMP REQUIRED)
 


### PR DESCRIPTION
building on MacOS seems to be an issue because the OpenMP dependency cannot be resolved.

With the `homebrew` package manager, this can be resolved. It offers a `libomp` package ([here](https://formulae.brew.sh/formula/libomp)), which can be used to resolve the OpenMP dependency. In addition to the installation of the `libomp` package, cmake needs to be informed about the non-standard `libomp` installation path. this patch adds this functionality.

To build the project on MacOS, install `libomp` with `homebrew`, and then build the project with the `USE_HOMEBREW=ON` environment variable set. The libomp install path can also be overriden once the `USE_HOMEBREW` flag is set, using the `HOMEBREW_OMP_PATH` environment variable.

e.g.
`PybindMatlab $ USE_HOMEBREW=ON python3 -m pip install ./project`