### PR TITLE
remove circumcented safety checks

### DIFF
--- a/project/src/CGsolver/eigen_cg.cpp
+++ b/project/src/CGsolver/eigen_cg.cpp
@@ -28,16 +28,10 @@ void checkVectorMatrixCompatibility(SpMat& A, RefVector& b){
 void cgTimingTest(SpMat&A, RefVector& b, RefVector& x0){
     Eigen::ConjugateGradient<SpMat, Eigen::Lower|Eigen::Upper, Eigen::SimplicialCholesky<SpMat, 1>> cg;
     VectorXd result;
-    try{
-        checkVectorMatrixCompatibility(A, b);
-    } catch (std::invalid_argument const&e){
-        std::cout<<"rows in rhs must match cols in matrix"<<std::endl;
-    }
-    try{
-        checkVectorMatrixCompatibility(A,x0);
-    } catch (std::invalid_argument const&e){
-        std::cout<<"rows in initial guess must match cols in matrix"<<std::endl;
-    }
+
+    checkVectorMatrixCompatibility(A, b);
+    checkVectorMatrixCompatibility(A,x0);
+
     cg.setTolerance(1e-7);
     cg.setMaxIterations(100000);
     cg.compute(A);
@@ -49,16 +43,10 @@ void cgTimingTest(SpMat&A, RefVector& b, RefVector& x0){
 VectorXd cg(SpMat& A, RefVector& b, RefVector& x0){
     Eigen::ConjugateGradient<SpMat, Eigen::Lower|Eigen::Upper, Eigen::SimplicialCholesky<SpMat, 1>> cg;
     VectorXd result;
-    try{
-        checkVectorMatrixCompatibility(A, b);
-    } catch (std::invalid_argument const&e){
-        std::cout<<"rows in rhs must match cols in matrix"<<std::endl;
-    }
-    try{
-        checkVectorMatrixCompatibility(A,x0);
-    } catch (std::invalid_argument const&e){
-        std::cout<<"rows in initial guess must match cols in matrix"<<std::endl;
-    }
+
+    checkVectorMatrixCompatibility(A, b);
+    checkVectorMatrixCompatibility(A,x0);
+    
     cg.setTolerance(1e-7);
     cg.setMaxIterations(100000);
     cg.compute(A);


### PR DESCRIPTION
the safety checks to ensure that the matrices are compatible are caught, and essentially discarded (with a message printed to stdout, but no further action).

when running the code like this, violations lead to invalid memory access in the downstream function that expects this compatibility to be valid. I think propagating the exception is the better way to handle this behaviour.

note: pybind will translate the exception appropriately to python, e.g.
```
Traceback (most recent call last):
  File "PybindMatlab/project/tests/unit_testing.py", line 46, in <module>
    wrongInputVector()
  File "PybindMatlab-fork/project/tests/unit_testing.py", line 30, in wrongInputVector
    eigenSolve = eigen.cg(A, b, x0)
                 ^^^^^^^^^^^^^^^^^^
ValueError: Rows and columns in matrix and vector must match.
```