### PR TITLE
utilise unittest library for unit testing

### DIFF
--- a/project/tests/unit_testing.py
+++ b/project/tests/unit_testing.py
@@ -2,46 +2,54 @@ import numpy as np
 import scipy as sp
 import eigen_cg as eigen
 
-def correctnessTest():
-    """
-    Testing small matrix solve comparing sci-py and eigen.
-    """
-    A = np.asarray([[4, 0, 0, 0],
-              [0, 5, 0, 0],
-              [0, 0, 3, 0],
-              [0, 0, 0, 2]])
-    b = np.asarray([-1,-0.5,-1,2])
-    x0 = np.asarray([0., 0., 0., 0.])
-    eigenSolve = eigen.cg(A, b, x0)
-    scipySolve = sp.linalg.solve(A, b)
-    diff = eigenSolve - scipySolve
-    assert np.linalg.norm(diff) < 1e-10
+import unittest
 
-def wrongInputVector():
-    """
-    Testing if exception handling wrong input vector-size
-    """
-    A = np.asarray([[4, 0, 0, 0],
-              [0, 5, 0, 0],
-              [0, 0, 3, 0],
-              [0, 0, 0, 2]])
-    b = np.asarray([-1,-0.5,-1,2])
-    x0 = np.asarray([])
-    eigenSolve = eigen.cg(A, b, x0)
+class TestCorrectness(unittest.TestCase):
+    def test_correctness(self):
+        """
+        Testing small matrix solve comparing sci-py and eigen.
+        """
+        A = np.asarray([[4, 0, 0, 0],
+                [0, 5, 0, 0],
+                [0, 0, 3, 0],
+                [0, 0, 0, 2]])
+        b = np.asarray([-1,-0.5,-1,2])
+        x0 = np.asarray([0., 0., 0., 0.])
+        eigenSolve = eigen.cg(A, b, x0)
+        scipySolve = sp.linalg.solve(A, b)
+        diff = eigenSolve - scipySolve
 
-def wrongInputMatrix():
-    """
-    Testing if exception handling wrong matrix-size
-    """
-    A = np.asarray([[4, 0, 0, 0],
-              [0, 5, 0, 0],
-              [0, 0, 3, 0],
-              [0, 0, 0, 2],
-              [5, 1, 2, 3]])
-    b = np.asarray([-1,-0.5,-1,2])
-    x0 = np.asarray([0.,0.,0.,0.])
-    eigenSolve = eigen.cg(A, b, x0)
+        self.assertTrue(np.linalg.norm(diff) < 1e-10)
 
-correctnessTest()
+class TestInputSizeValidation(unittest.TestCase):
+    def test_wrongInputVector(self):
+        """
+        Testing if exception handling wrong input vector-size
+        """
+        A = np.asarray([[4, 0, 0, 0],
+                [0, 5, 0, 0],
+                [0, 0, 3, 0],
+                [0, 0, 0, 2]])
+        b = np.asarray([-1,-0.5,-1,2])
+        x0 = np.asarray([])
 
+        with self.assertRaises(ValueError):
+            eigenSolve = eigen.cg(A, b, x0)
 
+    def test_wrongInputMatrix(self):
+        """
+        Testing if exception handling wrong matrix-size
+        """
+        A = np.asarray([[4, 0, 0, 0],
+                [0, 5, 0, 0],
+                [0, 0, 3, 0],
+                [0, 0, 0, 2],
+                [5, 1, 2, 3]])
+        b = np.asarray([-1,-0.5,-1,2])
+        x0 = np.asarray([0.,0.,0.,0.])
+        
+        with self.assertRaises(ValueError):
+            eigenSolve = eigen.cg(A, b, x0)
+
+if __name__=="__main__":
+    unittest.main()


### PR DESCRIPTION
the supposed unit tests do not utilise the builtin `unittest` library in python. this patch implements use of this library, with expected behaviour derived from the function names.

note: the functions have been renamed slightly because `unittest` requires 'test' to be part of functions that should be recognized as test cases, even within a class derived from `unittest.TestCase`.